### PR TITLE
fix: 실험실 컴포넌트 componentNames 필터 추가

### DIFF
--- a/components/threejs/laboratory-webgl.vue
+++ b/components/threejs/laboratory-webgl.vue
@@ -55,6 +55,7 @@ export default defineComponent({
   computed: {
     componentsNames () {
       return Object.keys(this.$options.components)
+        .filter(v => v[0] !== 'V') // todoc 빌드하면 vuetify 컴포넌트(v-card 등)이 components 옵션 안으로 들어와 'V'로 시작하는 컴포넌트는 제외해야 한다.
     }
   },
   mounted () {


### PR DESCRIPTION
[PR 요약]
* 실험실 컴포넌트 componentNames 필터 추가
  - 빌드 시 vuetify의 컴포넌트가 components 옵션으로 들어오므로 이니셜 V인 컴포넌트 필터링